### PR TITLE
Add more files to packaged Gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ cache:
   bundler: true
 rvm:
   - 2.6
+before_script: nvm use 12
 script: bundle exec rake

--- a/alchemy-dragonfly-s3.gemspec
+++ b/alchemy-dragonfly-s3.gemspec
@@ -15,7 +15,14 @@ Gem::Specification.new do |s|
   s.description = "AlchemyCMS Integration for the Dragonfly S3 datastore."
   s.license = "MIT"
 
-  s.files = Dir["app/**/*", "lib/**/*", "MIT-LICENSE", "README.md"]
+  s.files = Dir[
+    "app/**/*",
+    "lib/**/*",
+    "alchemy-dragonfly-s3.gemspec",
+    "CHANGELOG.md",
+    "MIT-LICENSE",
+    "README.md",
+  ]
 
   s.add_dependency "alchemy_cms", [">= 5.1.0.alpha", "< 6"]
   s.add_dependency "dragonfly-s3_data_store", "~> 1.3"


### PR DESCRIPTION
Although the Gem works without the gemspec it makes sense to have it
included in the packaged Gem published to Rubygems.