### PR TITLE
Change the way we load Alchemy factories in tests

### DIFF
--- a/spec/alchemy/attachment/s3_url_spec.rb
+++ b/spec/alchemy/attachment/s3_url_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "alchemy/test_support/factories/attachment_factory"
 
 RSpec.describe Alchemy::Attachment::S3Url do
   let(:attachment) { FactoryBot.create(:alchemy_attachment) }

--- a/spec/alchemy/attachment_spec.rb
+++ b/spec/alchemy/attachment_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "alchemy/test_support/factories/attachment_factory"
 
 RSpec.describe Alchemy::Attachment do
   describe "#url" do

--- a/spec/alchemy/dragonfly/s3/create_picture_thumb_spec.rb
+++ b/spec/alchemy/dragonfly/s3/create_picture_thumb_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "alchemy/test_support/factories/picture_factory"
 
 RSpec.describe Alchemy::Dragonfly::S3::CreatePictureThumb do
   let(:image) { File.new(File.expand_path("../../../fixtures/image.png", __dir__)) }

--- a/spec/alchemy/picture/s3_url_spec.rb
+++ b/spec/alchemy/picture/s3_url_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "alchemy/test_support/factories/picture_factory"
 
 RSpec.describe Alchemy::Picture::S3Url do
   let(:image) { File.new(File.expand_path("../../fixtures/image.png", __dir__)) }

--- a/spec/alchemy/picture_spec.rb
+++ b/spec/alchemy/picture_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "alchemy/test_support/factories/picture_factory"
 
 RSpec.describe Alchemy::Picture do
   describe "#url" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,16 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 require "factory_bot"
 
+require "alchemy/version"
+if Alchemy.gem_version >= Gem::Version.new("5.2.0")
+  require "alchemy/test_support"
+
+  FactoryBot.definition_file_paths.concat(Alchemy::TestSupport.factory_paths)
+  FactoryBot.reload
+else
+  require "alchemy/test_support/factories"
+end
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Alchemy 5.2 changed the way how factories get loaded to the preferred FactoryBot way.