### PR TITLE
Add a base_record model for Alchemy 4.0

### DIFF
--- a/app/models/alchemy/attachment/s3_url.rb
+++ b/app/models/alchemy/attachment/s3_url.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-module Alchemy
-  class Attachment < BaseRecord
-    class S3Url
-      def self.call(attachment)
-        attachment.file.remote_url
-      end
-    end
+require_dependency "alchemy/attachment"
+
+class Alchemy::Attachment::S3Url
+  def self.call(attachment)
+    attachment.file.remote_url
   end
 end

--- a/app/models/alchemy/picture/s3_url.rb
+++ b/app/models/alchemy/picture/s3_url.rb
@@ -1,41 +1,39 @@
 # frozen_string_literal: true
 
-module Alchemy
-  class Picture < BaseRecord
-    class S3Url
-      attr_reader :variant
+require_dependency "alchemy/picture"
 
-      # @param [Alchemy::PictureVariant]
-      #
-      def initialize(variant)
-        raise ArgumentError, "Variant missing!" if variant.nil?
+class Alchemy::Picture::S3Url
+  attr_reader :variant
 
-        @variant = variant
-      end
+  # @param [Alchemy::PictureVariant]
+  #
+  def initialize(variant)
+    raise ArgumentError, "Variant missing!" if variant.nil?
 
-      def call(*)
-        return variant.image.remote_url unless processible_image?
+    @variant = variant
+  end
 
-        ::Dragonfly.app(:alchemy_pictures).remote_url_for(uid)
-      end
+  def call(*)
+    return variant.image.remote_url unless processible_image?
 
-      private
+    ::Dragonfly.app(:alchemy_pictures).remote_url_for(uid)
+  end
 
-      def processible_image?
-        variant.image.is_a?(::Dragonfly::Job)
-      end
+  private
 
-      def uid
-        signature = PictureThumb::Signature.call(variant)
-        thumb = variant.picture.thumbs.detect { |t| t.signature == signature }
-        if thumb
-          uid = thumb.uid
-        else
-          uid = PictureThumb::Uid.call(signature, variant)
-          PictureThumb::Create.call(variant, signature, uid)
-        end
-        uid
-      end
+  def processible_image?
+    variant.image.is_a?(::Dragonfly::Job)
+  end
+
+  def uid
+    signature = Alchemy::PictureThumb::Signature.call(variant)
+    thumb = variant.picture.thumbs.detect { |t| t.signature == signature }
+    if thumb
+      uid = thumb.uid
+    else
+      uid = Alchemy::PictureThumb::Uid.call(signature, variant)
+      Alchemy::PictureThumb::Create.call(variant, signature, uid)
     end
+    uid
   end
 end

--- a/app/models/alchemy/picture_thumb.rb
+++ b/app/models/alchemy/picture_thumb.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency "alchemy/base_record"
+
 module Alchemy
   # The persisted version of a rendered picture variant
   #

--- a/app/models/alchemy/picture_thumb/create.rb
+++ b/app/models/alchemy/picture_thumb/create.rb
@@ -1,28 +1,25 @@
-module Alchemy
-  class PictureThumb < BaseRecord
-    # Stores the render result of a Alchemy::PictureVariant
-    # in the Dragonfly S3 datastore
-    #
-    class Create
-      def self.call(variant, signature, uid)
-        # create the thumb before uploading
-        # to prevent db race conditions
-        thumb = variant.picture.thumbs.create!(
-          picture: variant.picture,
-          signature: signature,
-          uid: uid,
-        )
-        begin
-          # fetch and process the image
-          image = variant.image
-          # upload the processed image
-          image.store(path: uid)
-        rescue RuntimeError, Excon::Error => e
-          Rails.logger.warn(e)
-          # destroy the thumb if processing or upload fails
-          thumb.destroy
-        end
-      end
+# frozen_string_literal: true
+
+require_dependency "alchemy/picture_thumb"
+
+class Alchemy::PictureThumb::Create
+  def self.call(variant, signature, uid)
+    # create the thumb before uploading
+    # to prevent db race conditions
+    thumb = variant.picture.thumbs.create!(
+      picture: variant.picture,
+      signature: signature,
+      uid: uid,
+    )
+    begin
+      # fetch and process the image
+      image = variant.image
+      # upload the processed image
+      image.store(path: uid)
+    rescue RuntimeError, Excon::Error => e
+      Rails.logger.warn(e)
+      # destroy the thumb if processing or upload fails
+      thumb.destroy
     end
   end
 end

--- a/app/models/alchemy/picture_thumb/signature.rb
+++ b/app/models/alchemy/picture_thumb/signature.rb
@@ -1,23 +1,21 @@
 # frozen_string_literal: true
 
-module Alchemy
-  class PictureThumb < BaseRecord
-    class Signature
-      # Returns a unique image process signature
-      #
-      # @param [Alchemy::PictureVariant]
-      #
-      # @return [String]
-      def self.call(variant)
-        steps_without_fetch = variant.image.steps.reject do |step|
-          step.is_a?(::Dragonfly::Job::Fetch)
-        end
+require_dependency "alchemy/picture_thumb"
 
-        steps_with_id = [[variant.picture.id]] + steps_without_fetch
-        job_string = steps_with_id.map(&:to_a).to_dragonfly_unique_s
-
-        Digest::SHA1.hexdigest(job_string)
-      end
+class Alchemy::PictureThumb::Signature
+  # Returns a unique image process signature
+  #
+  # @param [Alchemy::PictureVariant]
+  #
+  # @return [String]
+  def self.call(variant)
+    steps_without_fetch = variant.image.steps.reject do |step|
+      step.is_a?(::Dragonfly::Job::Fetch)
     end
+
+    steps_with_id = [[variant.picture.id]] + steps_without_fetch
+    job_string = steps_with_id.map(&:to_a).to_dragonfly_unique_s
+
+    Digest::SHA1.hexdigest(job_string)
   end
 end

--- a/app/models/alchemy/picture_thumb/uid.rb
+++ b/app/models/alchemy/picture_thumb/uid.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
-module Alchemy
-  class PictureThumb < BaseRecord
-    class Uid
-      # Returns a image variant uid for storage
-      #
-      # @param [String]
-      # @param [Alchemy::PictureVariant]
-      #
-      # @return [String]
-      def self.call(signature, variant)
-        picture = variant.picture
-        filename = variant.image_file_name || "image"
-        name = File.basename(filename, ".*").gsub(/[^\w.]+/, "_")
-        ext = variant.render_format
+require_dependency "alchemy/picture_thumb"
 
-        "pictures/#{picture.id}/#{signature}/#{name}.#{ext}"
-      end
-    end
+class Alchemy::PictureThumb::Uid
+  # Returns a image variant uid for storage
+  #
+  # @param [String]
+  # @param [Alchemy::PictureVariant]
+  #
+  # @return [String]
+  def self.call(signature, variant)
+    picture = variant.picture
+    filename = variant.image_file_name || "image"
+    name = File.basename(filename, ".*").gsub(/[^\w.]+/, "_")
+    ext = variant.render_format
+
+    "pictures/#{picture.id}/#{signature}/#{name}.#{ext}"
   end
 end

--- a/lib/alchemy/dragonfly/s3/engine.rb
+++ b/lib/alchemy/dragonfly/s3/engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "alchemy/version"
+
 module Alchemy
   module Dragonfly
     module S3
@@ -11,7 +13,7 @@ module Alchemy
         end
 
         config.to_prepare do
-          files = [
+          [
             "attachment_monkey_patch.rb",
             "picture_monkey_patch.rb",
             "essence_picture_monkey_patch.rb",
@@ -19,6 +21,10 @@ module Alchemy
             file = Alchemy::Dragonfly::S3::Engine.root.join("lib", "alchemy", filename)
             Rails.application.config.cache_classes ? require(file) : load(file)
           end
+        end
+
+        if Gem::Version.new(Alchemy.version) < Gem::Version.new("4.1")
+          paths["app/models"] << root.join("lib", "models")
         end
       end
     end

--- a/lib/models/alchemy/base_record.rb
+++ b/lib/models/alchemy/base_record.rb
@@ -1,0 +1,9 @@
+module Alchemy
+  def self.table_name_prefix
+    "alchemy_"
+  end
+
+  class BaseRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end


### PR DESCRIPTION
Alchemy 4.0 does not have the `BaseRecord`. It is introduced in 4.1