### PR TITLE
Fix race condition in CreatePictureThumb

### DIFF
--- a/spec/alchemy/dragonfly/s3/create_picture_thumb_spec.rb
+++ b/spec/alchemy/dragonfly/s3/create_picture_thumb_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe Alchemy::Dragonfly::S3::CreatePictureThumb do
     expect { subject }.to change { variant.picture.thumbs.reload.length }.by(1)
   end
 
+  context "with a thumb already existing" do
+    let!(:thumb) do
+      Alchemy::PictureThumb.create!(
+        picture: picture,
+        signature: "1234",
+        uid: "/foo/baz",
+      )
+    end
+
+    it "does not create a new thumb" do
+      expect { subject }.to_not change { picture.thumbs.reload.length }
+    end
+  end
+
   context "with an invalid picture" do
     let(:picture) { FactoryBot.build(:alchemy_picture) }
 


### PR DESCRIPTION
In a multi concurrent application server (like Puma) it happens that a thumb might already exist for a given signature during the very short timeframe of finding it vs creating it.

Using ARs [create_or_find_by!](https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/activerecord/lib/active_record/relation.rb#L218) do avoid ActiveRecord::RecordNotUnique errors. ActiveStorage does the exact same thing to avoid concurrency issues.

Refs AlchemyCMS/alchemy_cms#2429