### PR TITLE
Configure the engine after initialize

### DIFF
--- a/lib/alchemy/dragonfly/s3/engine.rb
+++ b/lib/alchemy/dragonfly/s3/engine.rb
@@ -6,7 +6,7 @@ module Alchemy
       class Engine < ::Rails::Engine
         engine_name "alchemy_dragonfly_s3"
 
-        config.to_prepare do
+        config.after_initialize do
           Alchemy::Attachment.url_class = Alchemy::Attachment::S3Url
           Alchemy::Picture.url_class = Alchemy::Picture::S3Url
           Alchemy::PictureThumb.storage_class = Alchemy::Dragonfly::S3::Store


### PR DESCRIPTION
When the code inside to_prepare is executed the Alchemy.user_class is nil and it fails when called to inizialize the Alchemy::Models