### PR TITLE
Pass rubygems_api_key secret to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,3 +16,4 @@ jobs:
     secrets:
       app_id: ${{ vars.ALCHEMY_BOT_APP_ID }}
       app_private_key: ${{ secrets.ALCHEMY_BOT_APP_PRIVATE_KEY }}
+      rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds the `rubygems_api_key` secret to the release workflow call
- Required for the reusable release workflow to publish gems to RubyGems

## Test plan
- [ ] Verify the workflow syntax is valid
- [ ] Test by triggering a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)